### PR TITLE
Don't override initialize method

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
           ruby-version: 2.7.x
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -yqq install libpq-dev build-essential libcurl4-openssl-dev
           gem install bundler
           bundle install --jobs 4 --retry 3

--- a/.rspec_status
+++ b/.rspec_status
@@ -1,19 +1,17 @@
-example_id                            | status  | run_time        |
-------------------------------------- | ------- | --------------- |
-./spec/remote_record_spec.rb[1:1:1]   | pending | 0.063 seconds   |
-./spec/remote_record_spec.rb[1:1:2]   | pending | 0.00046 seconds |
-./spec/remote_record_spec.rb[1:2:1:1] | passed  | 0.02975 seconds |
-./spec/remote_record_spec.rb[1:2:2:1] | passed  | 0.00087 seconds |
-./spec/remote_record_spec.rb[1:2:3:1] | passed  | 0.00081 seconds |
-./spec/remote_record_spec.rb[1:2:4:1] | passed  | 0.00069 seconds |
-./spec/remote_record_spec.rb[1:3:1:1] | passed  | 0.02652 seconds |
-./spec/remote_record_spec.rb[1:3:1:2] | passed  | 0.01074 seconds |
-./spec/remote_record_spec.rb[1:3:1:3] | passed  | 0.2207 seconds  |
-./spec/remote_record_spec.rb[1:3:2:1] | passed  | 0.01851 seconds |
-./spec/remote_record_spec.rb[1:3:2:2] | passed  | 0.03073 seconds |
-./spec/remote_record_spec.rb[1:3:2:3] | passed  | 0.02002 seconds |
-./spec/remote_record_spec.rb[1:3:3:1] | passed  | 0.01269 seconds |
-./spec/remote_record_spec.rb[1:3:4:1] | passed  | 0.00145 seconds |
-./spec/remote_record_spec.rb[1:3:4:2] | passed  | 0.00235 seconds |
-./spec/remote_record_spec.rb[1:3:4:3] | passed  | 0.00135 seconds |
-./spec/remote_record_spec.rb[1:3:4:4] | passed  | 0.00113 seconds |
+example_id                            | status | run_time        |
+------------------------------------- | ------ | --------------- |
+./spec/remote_record_spec.rb[1:1:1:1] | passed | 0.14453 seconds |
+./spec/remote_record_spec.rb[1:1:2:1] | passed | 0.00129 seconds |
+./spec/remote_record_spec.rb[1:1:3:1] | passed | 0.00152 seconds |
+./spec/remote_record_spec.rb[1:1:4:1] | passed | 0.00155 seconds |
+./spec/remote_record_spec.rb[1:2:1:1] | passed | 0.04694 seconds |
+./spec/remote_record_spec.rb[1:2:1:2] | passed | 0.01667 seconds |
+./spec/remote_record_spec.rb[1:2:1:3] | passed | 0.0262 seconds  |
+./spec/remote_record_spec.rb[1:2:2:1] | passed | 0.01687 seconds |
+./spec/remote_record_spec.rb[1:2:2:2] | passed | 0.04413 seconds |
+./spec/remote_record_spec.rb[1:2:2:3] | passed | 0.02758 seconds |
+./spec/remote_record_spec.rb[1:2:3:1] | passed | 0.01457 seconds |
+./spec/remote_record_spec.rb[1:2:4:1] | passed | 0.00197 seconds |
+./spec/remote_record_spec.rb[1:2:4:2] | passed | 0.00773 seconds |
+./spec/remote_record_spec.rb[1:2:4:3] | passed | 0.00188 seconds |
+./spec/remote_record_spec.rb[1:2:4:4] | passed | 0.00184 seconds |

--- a/.rspec_status
+++ b/.rspec_status
@@ -1,17 +1,19 @@
-example_id                            | status | run_time        |
-------------------------------------- | ------ | --------------- |
-./spec/remote_record_spec.rb[1:1:1:1] | passed | 0.0768 seconds  |
-./spec/remote_record_spec.rb[1:1:2:1] | passed | 0.00075 seconds |
-./spec/remote_record_spec.rb[1:1:3:1] | passed | 0.00071 seconds |
-./spec/remote_record_spec.rb[1:1:4:1] | passed | 0.00059 seconds |
-./spec/remote_record_spec.rb[1:2:1:1] | passed | 0.0275 seconds  |
-./spec/remote_record_spec.rb[1:2:1:2] | passed | 0.01085 seconds |
-./spec/remote_record_spec.rb[1:2:1:3] | passed | 0.02153 seconds |
-./spec/remote_record_spec.rb[1:2:2:1] | passed | 0.01056 seconds |
-./spec/remote_record_spec.rb[1:2:2:2] | passed | 0.02645 seconds |
-./spec/remote_record_spec.rb[1:2:2:3] | passed | 0.01789 seconds |
-./spec/remote_record_spec.rb[1:2:3:1] | passed | 0.00969 seconds |
-./spec/remote_record_spec.rb[1:2:4:1] | passed | 0.14647 seconds |
-./spec/remote_record_spec.rb[1:2:4:2] | passed | 0.00442 seconds |
-./spec/remote_record_spec.rb[1:2:4:3] | passed | 0.00499 seconds |
-./spec/remote_record_spec.rb[1:2:4:4] | passed | 0.011 seconds   |
+example_id                            | status  | run_time        |
+------------------------------------- | ------- | --------------- |
+./spec/remote_record_spec.rb[1:1:1]   | pending | 0.063 seconds   |
+./spec/remote_record_spec.rb[1:1:2]   | pending | 0.00046 seconds |
+./spec/remote_record_spec.rb[1:2:1:1] | passed  | 0.02975 seconds |
+./spec/remote_record_spec.rb[1:2:2:1] | passed  | 0.00087 seconds |
+./spec/remote_record_spec.rb[1:2:3:1] | passed  | 0.00081 seconds |
+./spec/remote_record_spec.rb[1:2:4:1] | passed  | 0.00069 seconds |
+./spec/remote_record_spec.rb[1:3:1:1] | passed  | 0.02652 seconds |
+./spec/remote_record_spec.rb[1:3:1:2] | passed  | 0.01074 seconds |
+./spec/remote_record_spec.rb[1:3:1:3] | passed  | 0.2207 seconds  |
+./spec/remote_record_spec.rb[1:3:2:1] | passed  | 0.01851 seconds |
+./spec/remote_record_spec.rb[1:3:2:2] | passed  | 0.03073 seconds |
+./spec/remote_record_spec.rb[1:3:2:3] | passed  | 0.02002 seconds |
+./spec/remote_record_spec.rb[1:3:3:1] | passed  | 0.01269 seconds |
+./spec/remote_record_spec.rb[1:3:4:1] | passed  | 0.00145 seconds |
+./spec/remote_record_spec.rb[1:3:4:2] | passed  | 0.00235 seconds |
+./spec/remote_record_spec.rb[1:3:4:3] | passed  | 0.00135 seconds |
+./spec/remote_record_spec.rb[1:3:4:4] | passed  | 0.00113 seconds |

--- a/lib/remote_record/reference.rb
+++ b/lib/remote_record/reference.rb
@@ -29,8 +29,6 @@ module RemoteRecord
     included do
       attr_accessor :fetching
 
-      scope :skip_fetching, -> { where(fetching: false) }
-
       after_initialize do |reference|
         reference.fetching = true if reference.fetching.nil?
         config = reference.class.remote_record_class.default_config.merge(

--- a/lib/remote_record/reference.rb
+++ b/lib/remote_record/reference.rb
@@ -29,7 +29,10 @@ module RemoteRecord
     included do
       attr_accessor :fetching
 
+      scope :skip_fetching, -> { where(fetching: false) }
+
       after_initialize do |reference|
+        reference.fetching = true if reference.fetching.nil?
         config = reference.class.remote_record_class.default_config.merge(
           reference.class.remote_record_config.to_h
         )
@@ -49,13 +52,8 @@ module RemoteRecord
         instance.respond_to?(method_name, false)
       end
 
-      def initialize(fetching: true, **args)
-        @fetching = fetching
-        super
-      end
-
       def fetch_remote_resource
-        instance.fetch if @fetching
+        instance.fetch if fetching
       end
 
       def fresh

--- a/lib/remote_record/version.rb
+++ b/lib/remote_record/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RemoteRecord
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/remote_record_spec.rb
+++ b/spec/remote_record_spec.rb
@@ -36,37 +36,6 @@ RSpec.describe RemoteRecord do
     initialize_reference
   end
 
-  describe '#skip_fetching' do
-    before do
-      skip 'relies on database'
-      initialization
-    end
-
-    subject(:scoped) { reference_const_name.constantize.skip_fetching }
-    let(:initialize_reference) do
-      stub_const(reference_const_name, Class.new(ActiveRecord::Base) do
-        attr_accessor :remote_resource_id
-
-        # Don't attempt a database connection to load the schema
-        def self.load_schema!
-          @columns_hash = {}
-        end
-
-        include RemoteRecord
-        remote_record remote_record_class: 'RemoteRecord::Dummy::Record'
-      end)
-    end
-
-    it 'does not make any requests' do
-      scoped.first
-      expect(a_request(:get, 'https://jsonplaceholder.typicode.com/todos/1')).not_to have_been_made
-    end
-
-    it 'does not make any requests' do
-      expect(scoped.first).to be_a Dummy::RecordReference
-    end
-  end
-
   describe '#remote_record' do
     context 'when all requirements are present' do
       it 'does not raise an error' do

--- a/spec/remote_record_spec.rb
+++ b/spec/remote_record_spec.rb
@@ -36,6 +36,37 @@ RSpec.describe RemoteRecord do
     initialize_reference
   end
 
+  describe '#skip_fetching' do
+    before do
+      skip 'relies on database'
+      initialization
+    end
+
+    subject(:scoped) { reference_const_name.constantize.skip_fetching }
+    let(:initialize_reference) do
+      stub_const(reference_const_name, Class.new(ActiveRecord::Base) do
+        attr_accessor :remote_resource_id
+
+        # Don't attempt a database connection to load the schema
+        def self.load_schema!
+          @columns_hash = {}
+        end
+
+        include RemoteRecord
+        remote_record remote_record_class: 'RemoteRecord::Dummy::Record'
+      end)
+    end
+
+    it 'does not make any requests' do
+      scoped.first
+      expect(a_request(:get, 'https://jsonplaceholder.typicode.com/todos/1')).not_to have_been_made
+    end
+
+    it 'does not make any requests' do
+      expect(scoped.first).to be_a Dummy::RecordReference
+    end
+  end
+
   describe '#remote_record' do
     context 'when all requirements are present' do
       it 'does not raise an error' do
@@ -112,7 +143,7 @@ RSpec.describe RemoteRecord do
         expect(remote_reference.title).to eq('delectus aut autem')
       end
 
-      it 'makes a additional request to fetch a fresh instance', :vcr do
+      it 'makes an additional request to fetch a fresh instance', :vcr do
         remote_reference
         remote_reference.completed
         remote_reference.fresh.title

--- a/spec/vcr/RemoteRecord/_fetch_remote_resource/when_memoize_is_true/makes_an_additional_request_to_fetch_a_fresh_instance.yml
+++ b/spec/vcr/RemoteRecord/_fetch_remote_resource/when_memoize_is_true/makes_an_additional_request_to_fetch_a_fresh_instance.yml
@@ -1,0 +1,161 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://jsonplaceholder.typicode.com/todos/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 15 Dec 2020 14:25:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dbee0cb1bc4301fc742a762aefa34f8911608042319; expires=Thu, 14-Jan-21
+        14:25:19 GMT; path=/; domain=.typicode.com; HttpOnly; SameSite=Lax
+      X-Powered-By:
+      - Express
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Reset:
+      - '1606526533'
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - max-age=43200
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"53-hfEnumeNh6YirfjyjaujcOPPT+s"
+      Via:
+      - 1.1 vegur
+      Cf-Cache-Status:
+      - HIT
+      Age:
+      - '23990'
+      Cf-Request-Id:
+      - '070863a702000042331d832000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=%2FWqxgqu7i%2Fm5AuY4%2BLj7IZBSLio08PLi7HsnG7%2Bzfu2P54r0ifHiY96KcZ5I7dcRR5zTvEjBz6vYq3OfKCHY1JHarpCiqXnbnDvU9xZIshlsNrJmv14%2BEEHRDj%2Br"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6020d55198ad4233-LHR
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "userId": 1,
+          "id": 1,
+          "title": "delectus aut autem",
+          "completed": false
+        }
+  recorded_at: Tue, 15 Dec 2020 14:25:19 GMT
+- request:
+    method: get
+    uri: https://jsonplaceholder.typicode.com/todos/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.1.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 15 Dec 2020 14:25:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd5901d5e3905d7532c929d5cf3e637fc1608042319; expires=Thu, 14-Jan-21
+        14:25:19 GMT; path=/; domain=.typicode.com; HttpOnly; SameSite=Lax
+      X-Powered-By:
+      - Express
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Remaining:
+      - '999'
+      X-Ratelimit-Reset:
+      - '1606526533'
+      Vary:
+      - Origin, Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - max-age=43200
+      Pragma:
+      - no-cache
+      Expires:
+      - "-1"
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"53-hfEnumeNh6YirfjyjaujcOPPT+s"
+      Via:
+      - 1.1 vegur
+      Cf-Cache-Status:
+      - HIT
+      Age:
+      - '23990'
+      Cf-Request-Id:
+      - '070863a77100002d134a965000000001'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report?s=n5i15dqL5w8Wmt%2F%2FFb4n5Xwi3671pOIQWxYcQtvHbNu5UdSADeye5IpdT3URCPqnvYupSicIZZ%2BrVMAq5GpsS%2Fno%2BKtC11l7rtvzMhGiz3EVprF0eMgjSWatTlDX"}],"group":"cf-nel","max_age":604800}'
+      Nel:
+      - '{"report_to":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6020d5524e9d2d13-LHR
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "userId": 1,
+          "id": 1,
+          "title": "delectus aut autem",
+          "completed": false
+        }
+  recorded_at: Tue, 15 Dec 2020 14:25:19 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
As it turns out, overriding `initialize` for `ActiveRecord::Base` is a bad idea. So instead we're introducing a transient attribute that we'll default to `true` after initialize.

Closes #15 