### PR TITLE
rescue_from support

### DIFF
--- a/.rspec_status
+++ b/.rspec_status
@@ -1,17 +1,18 @@
 example_id                            | status | run_time        |
 ------------------------------------- | ------ | --------------- |
-./spec/remote_record_spec.rb[1:1:1:1] | passed | 0.08357 seconds |
-./spec/remote_record_spec.rb[1:1:2:1] | passed | 0.00076 seconds |
-./spec/remote_record_spec.rb[1:1:3:1] | passed | 0.00073 seconds |
-./spec/remote_record_spec.rb[1:1:4:1] | passed | 0.0006 seconds  |
-./spec/remote_record_spec.rb[1:2:1:1] | passed | 0.02826 seconds |
-./spec/remote_record_spec.rb[1:2:1:2] | passed | 0.01103 seconds |
-./spec/remote_record_spec.rb[1:2:1:3] | passed | 0.01912 seconds |
-./spec/remote_record_spec.rb[1:2:2:1] | passed | 0.00967 seconds |
-./spec/remote_record_spec.rb[1:2:2:2] | passed | 0.02684 seconds |
-./spec/remote_record_spec.rb[1:2:2:3] | passed | 0.01809 seconds |
-./spec/remote_record_spec.rb[1:2:3:1] | passed | 0.01003 seconds |
-./spec/remote_record_spec.rb[1:2:4:1] | passed | 0.00165 seconds |
-./spec/remote_record_spec.rb[1:2:4:2] | passed | 0.00529 seconds |
-./spec/remote_record_spec.rb[1:2:4:3] | passed | 0.00114 seconds |
-./spec/remote_record_spec.rb[1:2:4:4] | passed | 0.001 seconds   |
+./spec/remote_record_spec.rb[1:1:1:1] | passed | 0.09685 seconds |
+./spec/remote_record_spec.rb[1:1:2:1] | passed | 0.00107 seconds |
+./spec/remote_record_spec.rb[1:1:3:1] | passed | 0.00098 seconds |
+./spec/remote_record_spec.rb[1:1:4:1] | passed | 0.0008 seconds  |
+./spec/remote_record_spec.rb[1:1:5:1] | passed | 0.00221 seconds |
+./spec/remote_record_spec.rb[1:2:1:1] | passed | 0.03211 seconds |
+./spec/remote_record_spec.rb[1:2:1:2] | passed | 0.01281 seconds |
+./spec/remote_record_spec.rb[1:2:1:3] | passed | 0.01994 seconds |
+./spec/remote_record_spec.rb[1:2:2:1] | passed | 0.01098 seconds |
+./spec/remote_record_spec.rb[1:2:2:2] | passed | 0.02663 seconds |
+./spec/remote_record_spec.rb[1:2:2:3] | passed | 0.01775 seconds |
+./spec/remote_record_spec.rb[1:2:3:1] | passed | 0.01437 seconds |
+./spec/remote_record_spec.rb[1:2:4:1] | passed | 0.00181 seconds |
+./spec/remote_record_spec.rb[1:2:4:2] | passed | 0.00324 seconds |
+./spec/remote_record_spec.rb[1:2:4:3] | passed | 0.00146 seconds |
+./spec/remote_record_spec.rb[1:2:4:4] | passed | 0.00179 seconds |

--- a/lib/remote_record.rb
+++ b/lib/remote_record.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support/concern'
+require 'active_support/rescuable'
 require 'remote_record/base'
 require 'remote_record/class_lookup'
 require 'remote_record/config'

--- a/lib/remote_record/base.rb
+++ b/lib/remote_record/base.rb
@@ -3,6 +3,8 @@
 module RemoteRecord
   # Remote record classes should inherit from this class and define #get.
   class Base
+    include ActiveSupport::Rescuable
+
     def self.default_config
       Config.defaults.merge(remote_record_class: self)
     end

--- a/lib/remote_record/reference.rb
+++ b/lib/remote_record/reference.rb
@@ -27,6 +27,7 @@ module RemoteRecord
 
     # rubocop:disable Metrics/BlockLength
     included do
+      include ActiveSupport::Rescuable
       attr_accessor :fetching
 
       after_initialize do |reference|
@@ -52,6 +53,8 @@ module RemoteRecord
 
       def fetch_remote_resource
         instance.fetch if fetching
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        rescue_with_handler(e) || raise
       end
 
       def fresh

--- a/lib/remote_record/version.rb
+++ b/lib/remote_record/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RemoteRecord
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
Done during the stream with @mkcode.

I figured out that we needed some sort of hook in the code to respond to `rescue_from` - more on that in this [blog post](https://simonecarletti.com/blog/2009/12/inside-ruby-on-rails-rescuable-and-rescue_from/#rescue_from-and-ruby) (thanks @weppos!).