### PR TITLE
Fix missing instance

### DIFF
--- a/.rspec_status
+++ b/.rspec_status
@@ -1,17 +1,17 @@
 example_id                            | status | run_time        |
 ------------------------------------- | ------ | --------------- |
-./spec/remote_record_spec.rb[1:1:1:1] | passed | 0.14453 seconds |
-./spec/remote_record_spec.rb[1:1:2:1] | passed | 0.00129 seconds |
-./spec/remote_record_spec.rb[1:1:3:1] | passed | 0.00152 seconds |
-./spec/remote_record_spec.rb[1:1:4:1] | passed | 0.00155 seconds |
-./spec/remote_record_spec.rb[1:2:1:1] | passed | 0.04694 seconds |
-./spec/remote_record_spec.rb[1:2:1:2] | passed | 0.01667 seconds |
-./spec/remote_record_spec.rb[1:2:1:3] | passed | 0.0262 seconds  |
-./spec/remote_record_spec.rb[1:2:2:1] | passed | 0.01687 seconds |
-./spec/remote_record_spec.rb[1:2:2:2] | passed | 0.04413 seconds |
-./spec/remote_record_spec.rb[1:2:2:3] | passed | 0.02758 seconds |
-./spec/remote_record_spec.rb[1:2:3:1] | passed | 0.01457 seconds |
-./spec/remote_record_spec.rb[1:2:4:1] | passed | 0.00197 seconds |
-./spec/remote_record_spec.rb[1:2:4:2] | passed | 0.00773 seconds |
-./spec/remote_record_spec.rb[1:2:4:3] | passed | 0.00188 seconds |
-./spec/remote_record_spec.rb[1:2:4:4] | passed | 0.00184 seconds |
+./spec/remote_record_spec.rb[1:1:1:1] | passed | 0.08357 seconds |
+./spec/remote_record_spec.rb[1:1:2:1] | passed | 0.00076 seconds |
+./spec/remote_record_spec.rb[1:1:3:1] | passed | 0.00073 seconds |
+./spec/remote_record_spec.rb[1:1:4:1] | passed | 0.0006 seconds  |
+./spec/remote_record_spec.rb[1:2:1:1] | passed | 0.02826 seconds |
+./spec/remote_record_spec.rb[1:2:1:2] | passed | 0.01103 seconds |
+./spec/remote_record_spec.rb[1:2:1:3] | passed | 0.01912 seconds |
+./spec/remote_record_spec.rb[1:2:2:1] | passed | 0.00967 seconds |
+./spec/remote_record_spec.rb[1:2:2:2] | passed | 0.02684 seconds |
+./spec/remote_record_spec.rb[1:2:2:3] | passed | 0.01809 seconds |
+./spec/remote_record_spec.rb[1:2:3:1] | passed | 0.01003 seconds |
+./spec/remote_record_spec.rb[1:2:4:1] | passed | 0.00165 seconds |
+./spec/remote_record_spec.rb[1:2:4:2] | passed | 0.00529 seconds |
+./spec/remote_record_spec.rb[1:2:4:3] | passed | 0.00114 seconds |
+./spec/remote_record_spec.rb[1:2:4:4] | passed | 0.001 seconds   |

--- a/lib/remote_record/reference.rb
+++ b/lib/remote_record/reference.rb
@@ -43,7 +43,7 @@ module RemoteRecord
       def method_missing(method_name, *_args, &_block)
         fetch_remote_resource unless @remote_record_config.memoize
 
-        @instance.public_send(method_name)
+        instance.public_send(method_name)
       end
 
       def respond_to_missing?(method_name, _include_private = false)

--- a/lib/remote_record/version.rb
+++ b/lib/remote_record/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RemoteRecord
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
`instance` doesn't actually get called until you try and fire a request or access an attribute, so `@instance` isn't instantiated if `fetching` is `false`. This seems to lead to some odd behavior that's quietly caused by an error like `undefined method 'attribute_name' for nil:NilClass` if you try to access `attribute_name` on an instance.

Minor version bump as it may change functionality folks might've depended upon.