### PR TITLE
Only use attr setter if response object is present

### DIFF
--- a/lib/remote_record/collection.rb
+++ b/lib/remote_record/collection.rb
@@ -39,9 +39,10 @@ module RemoteRecord
 
     def match_remote_resources(response)
       @relation.map do |record|
-        record.remote.attrs = response.find do |resource|
+        prefetched_record = response.find do |resource|
           yield(resource).to_s == record.public_send(@id_field).remote_resource_id
-        end || {}
+        end
+        record.remote.attrs = prefetched_record if prefetched_record.present?
         record
       end
     end

--- a/lib/remote_record/version.rb
+++ b/lib/remote_record/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RemoteRecord
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end


### PR DESCRIPTION
I realized 0.9.1 wasn't the real fix - that still runs the setter and marks that object as fetched.